### PR TITLE
Working demo syscall handler and cpu mode check

### DIFF
--- a/src/hardware/interrupts/idt.c
+++ b/src/hardware/interrupts/idt.c
@@ -56,7 +56,7 @@ INTERRUPT void _exception_div0(int_frame *frame) {
   WARN_MSG("Div by 0 exception handled\n\t->eip:%p cs:%p eflags:%p sp:%p ss:%p",
            frame->eip, frame->cs, frame->eflags, frame->sp, frame->ss);
 
-  frame->eip++; // go to next instruction
+  frame->eip += 2; // go to next instruction (Opcode f7 + f1 -> +2)
   return;
 }
 

--- a/src/hardware/interrupts/idt.h
+++ b/src/hardware/interrupts/idt.h
@@ -9,7 +9,8 @@
 
 #define IDT_NB_GATES 256
 
-//// IDT ////
+//// IDT/IVT ////
+// we'll referer to both as the IDT for simplicity's sake
 
 // offset to map the PIC at
 #define IDT_PIC_OFFSET 32             /// start of user defined interrupts
@@ -21,6 +22,8 @@ typedef enum idt_access {
       0x8E, // P = 1, DPL = 00, S = 0, Type = 1110 (32bit interrupt gate)
   TRAP_GATE_FLAGS =
       0x8F, /// P = 1, DPL = 00, S = 0, Type = 1111 (32bit trap gate)
+  INT_GATE_USER_FLAGS =
+      0xEE, /// P = 1, DPL = 11, S = 0, Type = 1110 (RING(PL)3)
 } idt_access;
 
 /// @brief entry in the IDT

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -8,6 +8,7 @@
 #include "hardware/interrupts/interrupts.h"
 #include "kernel.h"
 #include "klibc/libc.h"
+#include "syscalls/syscalls.h"
 
 #include "cp437.h"
 #include "log.h"
@@ -108,6 +109,9 @@ void kernel_main(void) {
 
   // initialize interrupts
   int_init();
+
+  // initialize syscalls
+  syscalls_init();
 
   // initalize the PS2 Keyboard controller
   kbd_init();

--- a/src/shell/cmds/cmds_debug.c
+++ b/src/shell/cmds/cmds_debug.c
@@ -1,5 +1,7 @@
 #include "cmds_debug.h"
+#include "../../klibc/get_line.h"
 #include "../../klibc/libc.h"
+#include "../../syscalls/syscalls.h"
 
 // INT only takes an immediate value sadly
 #define INTERRUPT_CMD(N, INT_NBR)                                              \
@@ -14,4 +16,39 @@
 INTERRUPT_CMD(int0, 0)
 INTERRUPT_CMD(int3, 3)
 INTERRUPT_CMD(intspurious, 33)
-INTERRUPT_CMD(intsyscall, 0x80)
+
+int cmd_intsyscall(uint8_t screen_nbr, int ac, char **av) {
+  vga_info screen_info = {.screen = screen_nbr, .print = true};
+  char input[5] = {0};
+  int eax = 0;
+
+  (void)ac, (void)av;
+  vga_printf(screen_info, "EAX(0..%d)> ", SYSCALL_NBR - 1);
+  if (!get_line(input, screen_nbr, sizeof(input) - sizeof(char))) { //-1 to \0
+    return 1;
+  }
+  eax = atoi(input);
+  if (eax < 0) {
+    vga_printf(screen_info, "Error: Selection has to be positive");
+    return 1;
+  } else if (eax >= SYSCALL_NBR) {
+    vga_printf(screen_info, "Error: syscall %d doesn't exist", eax);
+    return 1;
+  }
+
+  __asm__ volatile("INT $0x80" ::"a"(eax) :);
+  __asm__ volatile("MOV %0,%%eax" : "=a"(eax) :);
+  vga_printf(screen_info, "Syscall returned value %d", eax);
+  return 0;
+}
+
+int cmd_mode(uint8_t screen_nbr, int ac, char **av) {
+  vga_info screen_info = {.screen = screen_nbr, .print = true};
+  uint32_t cr0 = 0;
+
+  (void)ac, (void)av;
+  __asm__ volatile("MOV %%CR0, %0" : : "r"(cr0));
+  vga_printf(screen_info, "System is running in %s mode. CR0:%b",
+             (cr0 & 1) ? "protected" : "real", cr0);
+  return 0;
+}

--- a/src/shell/cmds/cmds_debug.h
+++ b/src/shell/cmds/cmds_debug.h
@@ -18,4 +18,12 @@ int cmd_int3(uint8_t screen_nbr, int ac, char **av);
 int cmd_intspurious(uint8_t screen_nbr, int ac, char **av);
 int cmd_intsyscall(uint8_t screen_nbr, int ac, char **av);
 
+#define CMD_MODE_SMSG "Checks the cpu current mode (PE)"
+#define CMD_MODE_LMSG                                                          \
+  "Real mode is the 16 bit compatibility mode, Protected mode allows the use " \
+  "of all the cpu features"
+
+/// @brief check cpu mode
+int cmd_mode(uint8_t screen_nbr, int ac, char **av);
+
 #endif

--- a/src/shell/commands.c
+++ b/src/shell/commands.c
@@ -4,13 +4,10 @@
 #include "cmds/cmd_hexdump.h"
 #include "cmds/cmd_kbd.h"
 #include "cmds/cmd_stack.h"
+#include "cmds/cmds_debug.h"
 #include "cmds/cmds_power.h"
 #include "cmds/cmds_vgatest.h"
 #include "shell.h"
-
-#ifdef DEBUG
-#include "cmds/cmds_debug.h"
-#endif
 // Available shell commands are defined here
 
 struct shell_cmd g_shell_cmds[] = {
@@ -49,8 +46,9 @@ struct shell_cmd g_shell_cmds[] = {
     {0, "int0", cmd_int0, {CMD_INT0_SMSG, CMD_INT_LMSG}},
     {0, "int3", cmd_int3, {CMD_INT3_SMSG, CMD_INT_LMSG}},
     {0, "intspurious", cmd_intspurious, {CMD_INTSPURIOUS_SMSG, CMD_INT_LMSG}},
-    {0, "intsyscall", cmd_intsyscall, {CMD_INTSYSCALL_SMSG, CMD_INT_LMSG}},
+    {0, "syscall", cmd_intsyscall, {CMD_INTSYSCALL_SMSG, CMD_INT_LMSG}},
 #endif
+    {0, "mode", cmd_mode, {CMD_MODE_SMSG, CMD_MODE_LMSG}},
 
     // cmds_power
     {0, "reboot", cmd_reboot, {CMD_REBOOT_SMSG, CMD_REBOOT_LMSG}},

--- a/src/syscalls/stub.s
+++ b/src/syscalls/stub.s
@@ -1,0 +1,8 @@
+.global syscall_stub /* export our stub */
+.extern syscall_handler
+
+syscall_stub:
+  pushal
+  call syscall_handler
+  popal
+  iret

--- a/src/syscalls/syscalls.c
+++ b/src/syscalls/syscalls.c
@@ -1,0 +1,37 @@
+#include "syscalls.h"
+
+#define DEMO_SYSCALL(NBR)                                                      \
+  void demo_syscall##NBR(struct syscall_parameters *params) {                  \
+    *params->ret = NBR + 42;                                                   \
+    INFO_MSG("Syscall " #NBR " called. params->ret:%u", *params->ret);         \
+  }
+
+DEMO_SYSCALL(0);
+DEMO_SYSCALL(1);
+DEMO_SYSCALL(2);
+
+struct syscall_entry syscall_table[SYSCALL_NBR] = {
+    {&demo_syscall0},
+    {&demo_syscall1},
+    {&demo_syscall2},
+};
+
+/// @brief called from our syscall stub
+
+void syscall_handler(struct general_regs regs) {
+
+  if (regs.eax >= SYSCALL_NBR) {
+    WARN_MSG("Syscall %#x not handled", regs.eax);
+    return;
+  }
+  struct syscall_parameters params = {&regs.eax, &regs.ebx, &regs.ecx,
+                                      &regs.edx, &regs.esi, &regs.edi,
+                                      &regs.ebp};
+  syscall_table[regs.eax].func(&params);
+  DEBUG_MSG("INT 0x80 (syscall) called with eax %u", *params.ret);
+}
+
+void syscalls_init() {
+  INFO_MSG("Initializing Syscalls...");
+  idt_add_gate(0x80, &syscall_stub, INT_GATE_USER_FLAGS);
+}

--- a/src/syscalls/syscalls.h
+++ b/src/syscalls/syscalls.h
@@ -1,0 +1,48 @@
+#ifndef SYSCALLS_H
+#define SYSCALLS_H
+
+#include "../hardware/interrupts/idt.h"
+#include "../hardware/interrupts/interrupts.h"
+#include "../log.h"
+
+// helpful reference for linux syscalls:
+// https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md
+
+/// number of handled syscalls
+#define SYSCALL_NBR 3
+
+/// @brief values passed to interrupt handler when pusha
+struct general_regs {
+  // popal: EAX, ECX, EDX, EBX, original ESP, EBP, ESI, and EDI
+  uint32_t edi;
+  uint32_t esi;
+  uint32_t ebp;
+  uint32_t esp;
+  uint32_t ebx;
+  uint32_t edx;
+  uint32_t ecx;
+  uint32_t eax;
+}; // not packed, hopefully fine?
+
+/// @brief parameters passed to syscalls
+struct syscall_parameters {
+  uint32_t *ret;  /// eax
+  uint32_t *arg0; /// ebx
+  uint32_t *arg1; /// ecx
+  uint32_t *arg2; /// edx
+  uint32_t *arg3; /// esi
+  uint32_t *arg4; /// edi
+  uint32_t *arg5; /// ebp
+};
+
+struct syscall_entry {
+  void (*func)(struct syscall_parameters *);
+};
+
+/// @brief syscall stub used to push user registeries in our syscall handler
+extern void syscall_stub();
+
+/// @brief Initialize syscall handlers !! Initialize interrutps first !!
+void syscalls_init();
+
+#endif


### PR DESCRIPTION
Implement a basic syscall demo that roughly matches linux (roughly) using an ASM stub as gcc's `ISR` ((attribute)) doesn't push general purpose registers.

Also fixes a small whoops in the division by 0 handler (The people of OSdev are right that it's atrocious but it still makes for a nice demo).